### PR TITLE
Small changes to the homepage blocks and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@
 Base Drupal install for Origins sites.
 
 When installing site run 
-```
+```shell script
 lando drush cset system.site uuid 55da8ecb-a446-49d7-9c85-df0c7228066e
 ```
+
+### Structure Sync
+After running drush config-import, also run
+```shell script
+lando drush ia
+```
+This imports the block content, menu links and taxonomy terms into the site.
+
+
+If you want to export any blocks, menus or taxonomy terms you have used run
+```shell script
+lando drush ea
+```
+
+For more information on the structure sync commands please visit https://www.drupal.org/project/structure_sync

--- a/config/sync/block.block.adviceguidanceguidanceportals.yml
+++ b/config/sync/block.block.adviceguidanceguidanceportals.yml
@@ -20,7 +20,7 @@ settings:
   id: 'block_content:d0893477-7cce-4dc1-b7f1-78b0eefcc400'
   label: 'Advice & Guidance - Guidance portals'
   provider: block_content
-  label_display: visible
+  label_display: '0'
   status: true
   info: ''
   view_mode: full

--- a/config/sync/block.block.adviceguidancehowdoi.yml
+++ b/config/sync/block.block.adviceguidancehowdoi.yml
@@ -20,7 +20,7 @@ settings:
   id: 'block_content:d01ecee4-906f-4bca-8837-5151fda64c71'
   label: 'Advice & Guidance - How do I?'
   provider: block_content
-  label_display: visible
+  label_display: '0'
   status: true
   info: ''
   view_mode: full

--- a/config/sync/block.block.highlightnicybersecuritycentre.yml
+++ b/config/sync/block.block.highlightnicybersecuritycentre.yml
@@ -18,9 +18,9 @@ provider: null
 plugin: 'block_content:d70f2992-7762-459f-8a0a-fed8d23e87d2'
 settings:
   id: 'block_content:d70f2992-7762-459f-8a0a-fed8d23e87d2'
-  label: 'Highlight - NI Cyber Security Centre'
+  label: 'NI Cyber Security Centre'
   provider: block_content
-  label_display: '0'
+  label_display: visible
   status: true
   info: ''
   view_mode: full

--- a/web/themes/custom/cybersecurity/templates/field/field--field-link-button.html.twig
+++ b/web/themes/custom/cybersecurity/templates/field/field--field-link-button.html.twig
@@ -1,0 +1,70 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set title_classes = [
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes }}>
+      {% for item in items %}
+        <div{{ item.attributes }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass('btn btn--more btn--primary tw-mt-5') }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes }}>
+    <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+    {% if multiple %}
+      <div>
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}


### PR DESCRIPTION
I thought I had forgotten to export the blocks and menu links using structure sync, but I had actually just not included instructions on how to import the content using structure sync. The README has been updated to include instructions.