### PR TITLE
hide moderation state block when viewing news node

### DIFF
--- a/config/sync/core.entity_view_display.node.news.default.yml
+++ b/config/sync/core.entity_view_display.node.news.default.yml
@@ -21,19 +21,14 @@ mode: default
 content:
   body:
     type: text_default
-    weight: 4
+    weight: 3
     region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
-  content_moderation_control:
-    weight: 0
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_photo:
     type: image
-    weight: 3
+    weight: 2
     region: content
     label: hidden
     settings:
@@ -45,7 +40,7 @@ content:
       image_link: ''
     third_party_settings: {  }
   field_published_date:
-    weight: 2
+    weight: 1
     label: hidden
     settings:
       timezone_override: ''
@@ -54,10 +49,11 @@ content:
     type: datetime_default
     region: content
   links:
-    weight: 1
+    weight: 0
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
+  content_moderation_control: true
   field_title: true
   search_api_excerpt: true


### PR DESCRIPTION
This is the block that appears when you have just created a news item that allows you to change the status to 'needs review' etc.
It was appearing for News but not for Publications - decided that it was a good idea to hide it for both to avoid confusing the user.
This was simply a case of managing the display for the News content type and moving the 'moderation control' field to 'disabled'