### PR TITLE
Amending front page meta title

### DIFF
--- a/config/sync/metatag.metatag_defaults.front.yml
+++ b/config/sync/metatag.metatag_defaults.front.yml
@@ -8,7 +8,7 @@ id: front
 label: 'Front page'
 tags:
   shortlink: '[site:url]'
-  title: '[site:name] | [current-page]'
+  title: '[current-page:title] | [site:name]'
   canonical_url: '[site:url]'
   og_type: Website
   og_url: '[site:url]'


### PR DESCRIPTION
I just noticed the front page title metatag was displaying the token instead of the current page title so I have amended this.