### PR TITLE
Srinter 748

### DIFF
--- a/web/modules/custom/cybersecurity_common/cybersecurity_common.module
+++ b/web/modules/custom/cybersecurity_common/cybersecurity_common.module
@@ -38,6 +38,11 @@ function cybersecurity_common_js_settings_alter(array &$settings) {
 /**
  * Generates a string representation for the given byte count.
  *
+ * This is a duplicate of format_size() I needed to alter the precision of
+ * the output file size. There are tickets in for a resolution to this
+ * https://www.drupal.org/project/drupal/issues/2837979 but this is a workaround
+ * for now.
+ *
  * @param int $size
  *   A size in bytes.
  * @param string $langcode
@@ -56,6 +61,7 @@ function cyber_format_size($size, $langcode = NULL) {
   $sign = $absolute_size / $size;
   foreach (['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'] as $unit) {
     $absolute_size /= Bytes::KILOBYTE;
+    // Changing precision from 2 to 1 so that a whole number is output.
     $rounded_size = round($absolute_size, 1);
     if ($rounded_size < Bytes::KILOBYTE) {
       break;

--- a/web/modules/custom/cybersecurity_common/cybersecurity_common.module
+++ b/web/modules/custom/cybersecurity_common/cybersecurity_common.module
@@ -6,6 +6,8 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Component\Utility\Bytes;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Implements hook_form_alter().
@@ -31,4 +33,59 @@ function cybersecurity_common_js_settings_alter(array &$settings) {
       $settings['editor']['formats'][$index]['editorSettings']['format_tags'] = "p;h2;h3;h4;h5;h6;pre";
     }
   endif;
+}
+
+/**
+ * Generates a string representation for the given byte count.
+ *
+ * @param $size
+ *   A size in bytes.
+ * @param $langcode
+ *   Optional language code to translate to a language other than what is used
+ *   to display the page.
+ *
+ * @return \Drupal\Core\StringTranslation\TranslatableMarkup
+ *   A translated string representation of the size.
+ */
+function cyber_format_size($size, $langcode = NULL) {
+  $absolute_size = abs($size);
+  if ($absolute_size < Bytes::KILOBYTE) {
+    return \Drupal::translation()->formatPlural($size, '1 byte', '@count bytes', [], ['langcode' => $langcode]);
+  }
+  // Create a multiplier to preserve the sign of $size.
+  $sign = $absolute_size / $size;
+  foreach (['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'] as $unit) {
+    $absolute_size /= Bytes::KILOBYTE;
+    $rounded_size = round($absolute_size, 1);
+    if ($rounded_size < Bytes::KILOBYTE) {
+      break;
+    }
+  }
+  $args = ['@size' => $rounded_size * $sign];
+  $options = ['langcode' => $langcode];
+  switch ($unit) {
+    case 'KB':
+      return new TranslatableMarkup('@size KB', $args, $options);
+
+    case 'MB':
+      return new TranslatableMarkup('@size MB', $args, $options);
+
+    case 'GB':
+      return new TranslatableMarkup('@size GB', $args, $options);
+
+    case 'TB':
+      return new TranslatableMarkup('@size TB', $args, $options);
+
+    case 'PB':
+      return new TranslatableMarkup('@size PB', $args, $options);
+
+    case 'EB':
+      return new TranslatableMarkup('@size EB', $args, $options);
+
+    case 'ZB':
+      return new TranslatableMarkup('@size ZB', $args, $options);
+
+    case 'YB':
+      return new TranslatableMarkup('@size YB', $args, $options);
+  }
 }

--- a/web/modules/custom/cybersecurity_common/cybersecurity_common.module
+++ b/web/modules/custom/cybersecurity_common/cybersecurity_common.module
@@ -38,9 +38,9 @@ function cybersecurity_common_js_settings_alter(array &$settings) {
 /**
  * Generates a string representation for the given byte count.
  *
- * @param $size
+ * @param int $size
  *   A size in bytes.
- * @param $langcode
+ * @param string $langcode
  *   Optional language code to translate to a language other than what is used
  *   to display the page.
  *

--- a/web/themes/custom/cybersecurity/cybersecurity.theme
+++ b/web/themes/custom/cybersecurity/cybersecurity.theme
@@ -167,7 +167,7 @@ function cybersecurity_preprocess_file_link(&$variables) {
   // Create file URL.
   $url = $file->createFileUrl(FALSE);
   // Format the file size.
-  $format_file_size = format_size($file_size);
+  $format_file_size = cyber_format_size($file_size);
 
   // User friendly MIME types:
   switch ($mime_type) {


### PR DESCRIPTION
The file size output for attachments needed to have no decimal point. format_size() is set to have a precision of 2. Upon research I couldn't find a way to alter this. I duplicated the code and renamed it cyber_format_size() and set the precision to 1. 